### PR TITLE
Update test coverage command in workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-go@v3
 
       - name: Generate test coverage
-        run: go test ./... -coverprofile=./cover.out -coverpkg=./...
+        run: go test ./... -coverprofile=./cover.out
 
       - name: Check test coverage
         id: coverage


### PR DESCRIPTION
Changed the go test command in the GitHub Actions workflow for testing coverage. Specifically, the `-coverpkg` flag has been removed, assuming all Go files in current and subdirectories are to be included in the coverage analysis.